### PR TITLE
 Move kde-l10n-{ar,ru,zhcn} to Depends 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -145,9 +145,8 @@ Depends: kdesudo, kscreen, polkit-kde-agent-1, kdepasswd, kfind,
  gtk3-engines-breeze, plasma-pa,
  kde-config-gtk-style, kde-config-gtk-style-preview,
  kde-config-screenlocker, kde-config-sddm, kde-style-oxygen-qt5,
- kmenuedit, ${misc:Depends}
-Suggests: anon-shared-kde-accessibility (= ${source:Version}),
- anon-shared-desktop-langpack-kde (= ${source:Version})
+ kmenuedit, anon-shared-desktop-langpack-kde (= ${source:Version}), ${misc:Depends}
+Suggests: anon-shared-kde-accessibility (= ${source:Version})
 Description: Recommended applications for Gateway/Workstation KDE desktop
  A metapackage, which installs a minimal, yet complete enough
  to contain the very basics, KDE applications.
@@ -213,16 +212,16 @@ Description: Fonts and language packages for better internationalization support
 
 Package: anon-shared-desktop-langpack-kde
 Architecture: all
-Depends: ${misc:Depends}
-Recommends: kde-l10n-ar, kde-l10n-bg, kde-l10n-bs,
+Depends: kde-l10n-ar, kde-l10n-ru, kde-l10n-zhcn, ${misc:Depends}
+Recommends: kde-l10n-bg, kde-l10n-bs,
  kde-l10n-ca, kde-l10n-cavalencia, kde-l10n-cs, kde-l10n-da, kde-l10n-de, kde-l10n-el, kde-l10n-engb,
  kde-l10n-es, kde-l10n-et, kde-l10n-eu, kde-l10n-fa, kde-l10n-fi, kde-l10n-fr, kde-l10n-ga,
  kde-l10n-gl, kde-l10n-he, kde-l10n-hr, kde-l10n-hu, kde-l10n-ia, kde-l10n-id, kde-l10n-is,
  kde-l10n-it, kde-l10n-ja, kde-l10n-kk, kde-l10n-km, kde-l10n-ko, kde-l10n-lt, kde-l10n-lv,
  kde-l10n-nb, kde-l10n-nds, kde-l10n-nl, kde-l10n-nn, kde-l10n-pa, kde-l10n-pl, kde-l10n-pt,
- kde-l10n-ptbr, kde-l10n-ro, kde-l10n-ru, kde-l10n-si, kde-l10n-sk, kde-l10n-sl, kde-l10n-sr,
+ kde-l10n-ptbr, kde-l10n-ro, kde-l10n-si, kde-l10n-sk, kde-l10n-sl, kde-l10n-sr,
  kde-l10n-sv, kde-l10n-tg, kde-l10n-th, kde-l10n-tr, kde-l10n-ug, kde-l10n-uk, kde-l10n-vi,
- kde-l10n-wa, kde-l10n-zhcn, kde-l10n-zhtw, anon-workstation-langpack-common (= ${source:Version})
+ kde-l10n-wa, kde-l10n-zhtw, anon-workstation-langpack-common (= ${source:Version})
 Description: Extra language support for the KDE desktop
  A metapackage, which includes extra language support for the
  KDE desktop.


### PR DESCRIPTION
Please correct me if I am wrong. My understanding is Whonix will install packages with --no-recommends. Therefore, this changes should be enough to get those packages installed by default.

I am not sure if this commit is the best way. If not, please teach me how I should do this. :)