### PR TITLE
Update control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -617,6 +617,7 @@ Depends: kicksecure-xfce, xfce4-xkb-plugin, xfce4-screenshooter,
  firefox-esr, gnome-system-monitor, gparted,
  whonix-libvirt,
  whonix-base-files, anon-base-files,
+ ntfs-3g, dosfstools
  ${misc:Depends}
 Description: Whonix Host packages for Freedom Hardware Design
  Designed to run on hardware with Freedom Hardware Design.


### PR DESCRIPTION
Adding package ntfs-3g and dosfstools to whonix-host-xfce-kvm-freedom dependencies. See https://forums.whonix.org/t/whonix-host-operating-system/3931/202