### PR TITLE
Bump python-msgpack to python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -113,7 +113,7 @@ Description: Dependencies for Whonix-Workstation CLI
 Package: whonix-workstation-packages-recommended-cli
 Architecture: all
 Depends: anon-ws-disable-stacked-tor, pwgen,
- python-msgpack, codecrypt, gpg, gpg-agent, dirmngr,
+ python3-msgpack, codecrypt, gpg, gpg-agent, dirmngr,
  magic-wormhole, diceware, makepasswd,
  bindp | dummy-dependency,
  ${misc:Depends}


### PR DESCRIPTION
ZeroNet now uses `python3`, and `python2` is removed from Debian as of `bullseye`.